### PR TITLE
FlowOwner returns wrong oldscreen in case of more than 2 screens in stack (always root screen)

### DIFF
--- a/app/src/main/java/co/lemonlabs/mortar/example/core/util/FlowOwner.java
+++ b/app/src/main/java/co/lemonlabs/mortar/example/core/util/FlowOwner.java
@@ -76,8 +76,8 @@ public abstract class FlowOwner<S extends Blueprint, V extends View & CanShowScr
 
         S oldScreen = null;
         if (flowDirection == Flow.Direction.FORWARD && backstack.size() > 1) {
-            List<Backstack.Entry> entries = Lists.newArrayList(backstack);
-            Backstack.Entry oldEntry = entries.get(entries.size() - 1);
+            List<Backstack.Entry> entries = Lists.newArrayList(backstack.reverseIterator());
+            Backstack.Entry oldEntry = entries.get(entries.size() - 2);
             //noinspection unchecked
             oldScreen = (S) oldEntry.getScreen();
         }


### PR DESCRIPTION
In my app i have 3 screens implementing StateBlueprint. If i go from 1st screen to 2nd, and then back to 1st, state of 1st screen is restored correctly. But if 3rd screen is opened from 2nd and then back to 2nd and 1st, states of 1st a 2nd screen are not restored.
In current realisation FlowOwner always returns root screen.

In method go of FlowOwner flow backstack is transformed to list of backstack entry.
Old screen is retrieved as last entry of resulting list.

```
List<Backstack.Entry> entries = Lists.newArrayList(backstack);
Backstack.Entry oldEntry = entries.get(entries.size() - 1);
```

Old entry is always first screen in stack (tail), because backstack is Iterable, which returns iterator of Deque. This iterator goes from first(head) to last(tail). Head is new screen. It was previously peeked:

```
S newScreen = (S) backstack.current().getScreen();
```

So to get old screen we need to peek entry after head (iterating through default iterator).
Possible solution is to reverse iterator and peek element at position = size - 2:

```
List<Backstack.Entry> entries = Lists.newArrayList(backstack.reverseIterator());
Backstack.Entry oldEntry = entries.get(entries.size() - 2);
```
