### PR TITLE
If child view has user defined id do not set generated id

### DIFF
--- a/app/src/main/java/co/lemonlabs/mortar/example/core/util/ScreenConductor.java
+++ b/app/src/main/java/co/lemonlabs/mortar/example/core/util/ScreenConductor.java
@@ -187,7 +187,8 @@ public class ScreenConductor<S extends Blueprint> implements CanShowScreen<S>, C
         MortarScope newChildScope = myScope.requireChild(screen);
         Context childContext = newChildScope.createContext(context);
         View newChild = Layouts.createView(childContext, screen);
-        newChild.setId(viewId);
+        if (newChild.getId() == View.NO_ID)
+            newChild.setId(viewId);
         return newChild;
     }
 


### PR DESCRIPTION
In case user defines own id for view, he'll be unable to use it because it will be replaced with generated one.
